### PR TITLE
Fix: Use Trusted Publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,5 +68,3 @@ jobs:
       - name: "Publish distribution \U0001F4E6 to PyPI"
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@0bf742be3ebe032c25dd15117957dc15d0cfc38d # ratchet:pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,6 @@ jobs:
       - name: "Publish distribution \U0001F4E6 to Test PyPI"
         uses: pypa/gh-action-pypi-publish@0bf742be3ebe032c25dd15117957dc15d0cfc38d # ratchet:pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
       - name: "Publish distribution \U0001F4E6 to PyPI"
         if: startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
We're using the Trusted Publisher for production.
https://docs.pypi.org/trusted-publishers/using-a-publisher/

This has been setup for SPDXMerge

Release-as: 0.1.2