### PR TITLE
fix: changed project name to publish to pypi env

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ with open(requirements_path, "r", encoding="utf8") as f:
     required = f.read().splitlines()
 
 setup(
-    name='spdxmerge',
-    version='0.1.2',
+    name='spdx-merge',
+    version='0.1.3',
     description="merges content of two/more spdx sboms",
     long_description_content_type="text/markdown",
     url="https://github.com/philips-software/SPDXMerge",


### PR DESCRIPTION
The 'spdxmerge' project name was already created , published and deleted for testing purpose in test pypi env
As PyPI does not allow for a filename to be reused, even once a project has been deleted and recreated.
Suggested to move to a new project name 'spdx-merge'