### PR TITLE
Port to spdx-tools==0.8.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,13 @@
-spdx-tools==0.7.1
+beartype==0.19.0
+boolean.py==4.0
 click==8.1.7
+license-expression==30.4.1
+ply==3.11
+pyparsing==3.2.1
+PyYAML==6.0.2
+rdflib==7.1.3
+semantic-version==2.10.0
+setuptools==75.8.0
+spdx-tools==0.8.3
+uritools==4.0.3
+xmltodict==0.14.2

--- a/spdxmerge/SPDXMerge.py
+++ b/spdxmerge/SPDXMerge.py
@@ -9,25 +9,30 @@ from spdxmerge.SPDXMergeLib import create_merged_spdx_document, write_file
 from spdxmerge.utils import read_docs
 
 
-
 @click.command()
-@click.option("--docpath", prompt="Directory path", required=True, help="Directory path with SPDX files to be merged")
-@click.option("--outpath", prompt="Output directory path", required=False, prompt_required=False, help="Output directory path where merged file should be saved")
-@click.option("--name", prompt="Product Name", required=True, help="Name of product for which SBoM is created")
-@click.option("--mergetype", prompt="Shallow Merge -0 or Deep Merge-1", help="Enter 0 for shallow merge , 1 for deep merge", type=click.Choice(['0','1']), default='1')
-@click.option("--author", prompt="SBoM Author name", required=True, help="Author who is writing SBoM")
-@click.option("--email", prompt="SBoM author email address", help="Email address of the author")
-@click.option("--docnamespace", prompt="Document namespace", help="URL where document is stored or organization URL", default="https://spdx.organization.name")
+@click.option("--docpath", prompt="Directory path", required=True,
+              help="Directory path with SPDX files to be merged")
+@click.option("--outpath", prompt="Output directory path", required=False, prompt_required=False,
+              help="Output directory path where merged file should be saved")
+@click.option("--name", prompt="Product Name", required=True,
+              help="Name of product for which SBoM is created")
+@click.option("--mergetype", prompt="Shallow Merge -0 or Deep Merge-1",
+              help="Enter 0 for shallow merge , 1 for deep merge", type=click.Choice(['0', '1']), default='1')
+@click.option("--author", prompt="SBoM Author name", required=True,
+              help="Author who is writing SBoM")
+@click.option("--docnamespace", prompt="Document namespace",
+              help="URL where document is stored or organization URL", default="https://spdx.organization.name")
 @click.option("--filetype", prompt="SBoM output file type SPDX tag value format - T or JSON - J",
-              help="Enter T for SPDX tag value format, J for JSON", type=click.Choice(['T', 't', 'J','j']), default='J')
-def main(docpath, name, mergetype, author, email, docnamespace, filetype, outpath = None):
+              help="Enter T for SPDX tag value format, J for JSON",
+              type=click.Choice(['T', 't', 'J', 'j']), default='J')
+def main(docpath, name, mergetype, author, docnamespace, filetype, outpath=None):
     """Tool provides option to merge SPDX SBoM files. Provides two options for merging,
     Shallow Merge: New SBoM is created only with external ref links to SBoM files to be merged
     Deep Merge: New SBoM file is created by appending package, relationship, license information
     """
     doc_list = read_docs(docpath)
     merge_type = "shallow" if mergetype == '0' else "deep"
-    doc = create_merged_spdx_document(doc_list, docnamespace, name, author, email, merge_type)
+    doc = create_merged_spdx_document(doc_list, docnamespace, name, author, merge_type)
     write_file(doc, filetype, merge_type, outpath)
 
 

--- a/spdxmerge/SPDXMergeLib.py
+++ b/spdxmerge/SPDXMergeLib.py
@@ -1,42 +1,43 @@
-import codecs
 import os
-from spdx.writers.json import write_document as write_json_document, InvalidDocumentError as JsonInvalidDocumentError
-from spdx.writers.tagvalue import write_document as write_tagvalue_document, InvalidDocumentError as TagvalueInvalidDocumentError
-from spdx.parsers.loggers import ErrorMessages
+from spdx_tools.spdx.writer.json.json_writer import (
+    write_document_to_file as write_json_document
+)
+from spdx_tools.spdx.writer.tagvalue.tagvalue_writer import (
+    write_document_to_file as write_tagvalue_document
+)
 from spdxmerge.SPDX_DeepMerge import SPDX_DeepMerger
-from spdxmerge.SPDX_ShallowMerge import SPDX_ShallowMerger
+#from spdxmerge.SPDX_ShallowMerge import SPDX_ShallowMerger
 
-def create_merged_spdx_document(doc_list, docnamespace, name, author, email, merge_type):
-    if merge_type == "deep":
-        merger = SPDX_DeepMerger(doc_list, docnamespace, name, author, email)
-        merger.doc_creationinfo()
-        merger.doc_packageinfo()
-        merger.doc_fileinfo()
-        merger.doc_snippetinfo()
-        merger.doc_other_license_info()
-        merger.doc_relationship_info()
-    elif merge_type == "shallow":
-        merger = SPDX_ShallowMerger(doc_list, docnamespace, name, author, email)
-        merger.doc_creationInfo()
-        merger.doc_externalDocumentRef()
+def create_merged_spdx_document(doc_list, docnamespace, name, author, merge_type):
+    #if merge_type == "deep":
+    merger = SPDX_DeepMerger(doc_list, docnamespace, name, author)
+    merger.doc_packageinfo()
+    merger.doc_fileinfo()
+    merger.doc_snippetinfo()
+    merger.doc_other_license_info()
+    merger.doc_relationship_info()
+#    elif merge_type == "shallow":
+#        merger = SPDX_ShallowMerger(doc_list, docnamespace, name, author, email)
+#        merger.doc_creationInfo()
+#        merger.doc_externalDocumentRef()
 
     return merger.get_document()
 
-def write_file(doc, filetype, merge_type, outpath = None):
+def write_file(doc, filetype, merge_type, outpath=None):
     result_filetype = "spdx" if filetype.lower() == "t" else "json"
     file = f"merged-SBoM-{merge_type}.{result_filetype}"
     if outpath:
         file = os.path.join(outpath, file)
-    with codecs.open(file, mode="w", encoding="utf-8") as out:
-        try:
-            if result_filetype == "spdx":
-                write_tagvalue_document(doc, out)
-            else:
-                write_json_document(doc, out)
-        except (TagvalueInvalidDocumentError, JsonInvalidDocumentError) as e:
-            print("Document is Invalid:\n\t", end="")
-            print("\n\t".join(e.args[0]))
-            messages = ErrorMessages()
-            doc.validate(messages)
-            print("\n".join(messages.messages))
-        print("File "+file+" is generated")
+    #with codecs.open(file, mode="w", encoding="utf-8") as out:
+        #try:
+        #if result_filetype == "spdx":
+        #    write_tagvalue_document(doc, out)
+        #else:
+    write_json_document(doc, file, validate=True)
+        #except (TagvalueInvalidDocumentError, JsonInvalidDocumentError) as e:
+        #    print("Document is Invalid:\n\t", end="")
+        #    print("\n\t".join(e.args[0]))
+        #    messages = ErrorMessages()
+        #    doc.validate(messages)
+        #    print("\n".join(messages.messages))
+    print("File "+file+" is generated")

--- a/spdxmerge/SPDX_DeepMerge.py
+++ b/spdxmerge/SPDX_DeepMerge.py
@@ -61,8 +61,9 @@ class SPDX_DeepMerger():
                 relationship_type=RelationshipType.DESCRIBES,
                 related_spdx_element_id=doc.creation_info.spdx_id
             )
-            doc.relationships += [relationship]
+            #doc.relationships += [relationship]
             #self.master_doc.relationships += doc.relationships
+            self.master_doc.relationships += [relationship]
 
     def doc_annotation_info(self):
         for doc in self.doc_list:

--- a/spdxmerge/SPDX_DeepMerge.py
+++ b/spdxmerge/SPDX_DeepMerge.py
@@ -35,7 +35,7 @@ class SPDX_DeepMerger():
 
     def doc_packageinfo(self):
         """
-        Append packges from document list
+        Append packages from document list
         """
         for doc in self.doc_list:
             self.master_doc.packages += doc.packages
@@ -49,8 +49,17 @@ class SPDX_DeepMerger():
             self.master_doc.snippets += doc.snippets
 
     def doc_other_license_info(self):
+        """
+        Append unique licenses to hasExtractedLicensingInfo
+        """
+        master_doc_eli_ids = []
         for doc in self.doc_list:
-            self.master_doc.extracted_licensing_info += doc.extracted_licensing_info
+            doc_eli = [
+                eli for eli in doc.extracted_licensing_info
+                if eli.license_id not in master_doc_eli_ids
+            ]
+            master_doc_eli_ids += [eli.license_id for eli in doc_eli]
+            self.master_doc.extracted_licensing_info += doc_eli
 
     def doc_relationship_info(self):
         for doc in self.doc_list:

--- a/spdxmerge/SPDX_DeepMerge.py
+++ b/spdxmerge/SPDX_DeepMerge.py
@@ -1,62 +1,73 @@
-from spdx.creationinfo import Person
-from spdx.license import License
-from spdx.document import Document
-from spdx.relationship import Relationship,RelationshipType
-from spdx.version import Version
-
-master_doc = Document()
+from datetime import datetime
+from spdx_tools.spdx.model import (
+    Document,
+    Relationship,
+    RelationshipType,
+    CreationInfo,
+    Actor,
+    ActorType
+)
 
 class SPDX_DeepMerger():
 
-    def __init__(self,doc_list=None,docnamespace=None,name=None,author=None,email=None):
+    def __init__(self,
+                 doc_list=None,
+                 docnamespace=None,
+                 name=None,
+                 author=None,
+                 email=None):
         self.doc_list = doc_list
-        self.docnamespace = docnamespace
-        self.name = name
-        self.author = author
-        self.emailaddr = email
+        # data_license is "CC0-1.0" by default
+        self.master_doc = Document(CreationInfo(
+            spdx_version="SPDX-2.3",
+            spdx_id="SPDXRef-DOCUMENT",
+            name=name,
+            document_namespace=docnamespace,
+            creators=[Actor(
+                actor_type=ActorType.ORGANIZATION,
+                name=author
+            )],
+            created=datetime.utcnow().replace(microsecond=0)
+        ))
 
     def get_document(self):
-        return master_doc
-
-    def doc_creationinfo(self):
-        master_doc.name = self.name
-        master_doc.version = Version(2,3) # TODO Need to check from where to take this. can not hardcode here
-        master_doc.spdx_id = self.docnamespace + "#SPDXRef-DOCUMENT"
-        master_doc.namespace = self.docnamespace
-        master_doc.data_license = License.from_identifier("CC0-1.0") #TODO Can not hardcode it here need to check from where to take it.
-        master_doc.creation_info.add_creator(Person(self.author,self.emailaddr))
-        master_doc.creation_info.set_created_now()
+        return self.master_doc
 
     def doc_packageinfo(self):
         """
         Append packges from document list
         """
         for doc in self.doc_list:
-            master_doc.packages.extend(doc.packages)
+            self.master_doc.packages += doc.packages
 
     def doc_fileinfo(self):
         for doc in self.doc_list:
-            master_doc.files.extend(doc.files)  #TODO Need to check this its not returning list
+            self.master_doc.files += doc.files
 
     def doc_snippetinfo(self):
         for doc in self.doc_list:
-            master_doc.snippet.extend(doc.snippet)
+            self.master_doc.snippets += doc.snippets
 
     def doc_other_license_info(self):
         for doc in self.doc_list:
-            master_doc.extracted_licenses.extend(doc.extracted_licenses)
+            self.master_doc.extracted_licensing_info += doc.extracted_licensing_info
 
     def doc_relationship_info(self):
         for doc in self.doc_list:
-            # Add 'DESCRIBES' relationship between master and child documents, then import all relationships in child docs
-            relationship = Relationship(master_doc.spdx_id+" "+RelationshipType.DESCRIBES.name+" "+doc.spdx_id)
-            master_doc.add_relationship(relationship)
-            #master_doc.relationships.extend(doc.relationships)
+            # Add 'DESCRIBES' relationship between master and child documents and
+            # then import all relationships in child docs
+            relationship = Relationship(
+                spdx_element_id=self.master_doc.creation_info.spdx_id,
+                relationship_type=RelationshipType.DESCRIBES,
+                related_spdx_element_id=doc.creation_info.spdx_id
+            )
+            doc.relationships += [relationship]
+            #self.master_doc.relationships += doc.relationships
 
     def doc_annotation_info(self):
         for doc in self.doc_list:
-            master_doc.annotations.extend(doc.annotations)
+            self.master_doc.annotations += doc.annotations
 
     def doc_review_info(self):
         for doc in self.doc_list:
-            master_doc.reviews.extend(doc.reviews)
+            self.master_doc.reviews += doc.reviews

--- a/spdxmerge/SPDX_DeepMerge.py
+++ b/spdxmerge/SPDX_DeepMerge.py
@@ -51,7 +51,7 @@ class SPDX_DeepMerger():
             # Add 'DESCRIBES' relationship between master and child documents, then import all relationships in child docs
             relationship = Relationship(master_doc.spdx_id+" "+RelationshipType.DESCRIBES.name+" "+doc.spdx_id)
             master_doc.add_relationship(relationship)
-            master_doc.relationships.extend(doc.relationships)
+            #master_doc.relationships.extend(doc.relationships)
 
     def doc_annotation_info(self):
         for doc in self.doc_list:

--- a/spdxmerge/SPDX_ShallowMerge.py
+++ b/spdxmerge/SPDX_ShallowMerge.py
@@ -1,10 +1,14 @@
-from spdx.checksum import Checksum,ChecksumAlgorithm
-from spdx.utils import NoAssert
-from spdx.creationinfo import Person
-from spdx.license import License
-from spdx.document import (Document,ExternalDocumentRef)
-from spdx.package import Package
-from spdx.version import Version
+from spdx_tools.spdx.model import (
+    Checksum,
+    ChecksumAlgorithm,
+    Actor,
+    Document,
+    ExternalDocumentRef,
+    Package,
+    Version,
+    SpdxNoAssertion
+)
+from spdx_tools.common.spdx_licensing import spdx_licensing
 
 master_doc = Document()
 
@@ -33,7 +37,7 @@ class SPDX_ShallowMerger():
         package.name = self.name
         package.version = "1.0"
         package.spdx_id = self.docnamespace + "#SPDXRef-DOCUMENT"
-        package.download_location = NoAssert()
+        package.download_location = SpdxNoAssertion()
 
         master_doc.add_package(package)
         for doc in self.doc_list:

--- a/spdxmerge/utils.py
+++ b/spdxmerge/utils.py
@@ -1,12 +1,12 @@
 import os
-from spdx.parsers import parse_anything
+from spdx_tools.spdx.parser import parse_anything
 from spdxmerge.checksum import sha1sum
 
 def read_docs(dir):
     doc_list = []
     doc_files = [f for f in os.listdir(dir) if f.endswith(('.json', '.spdx'))]
     for file in doc_files:
-        doc, _error = parse_anything.parse_file(dir+"/"+file)
+        doc = parse_anything.parse_file(dir+"/"+file)
         check_sum = sha1sum(dir+"/"+file)
         doc.comment = check_sum
         doc_list.append(doc)


### PR DESCRIPTION
This is a followup to https://github.com/philips-software/SPDXMerge/issues/122

Only deep merge is currently ported.

Removed `email` from click arguments.

This changeset is tested with the output of YoctoProject kirkstone [create-spdx.bbclass](https://git.yoctoproject.org/poky/tree/meta/classes/create-spdx.bbclass?h=kirkstone). Only some minor preprocessing is required for this merging tool to successfuly merge Yocto's SBOMs.

And now to the most important part: The created document passes the validator tool at https://tools.spdx.org/app/validate

The versions of web validator components are:
* Spdx online tools version : 1.3.2
* Java Tools version : 2.0.0-RC2 