### PR TITLE
Introduction of new param: rootdocpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Execute the command with the required inputs:
                          --email <org/author email>
                          --docnamespace <namespace for SPDX document>
                          --filetype <expected SBOM file format for JSON/T for Tag value>
+                         --rootdocpath <expects SBOM file in the docpath that should act as the root doc> (optional)
 ```  
 
 ### 🔹 **New Update: Version Input**  

--- a/spdxmerge/SPDXMerge.py
+++ b/spdxmerge/SPDXMerge.py
@@ -29,14 +29,17 @@ from spdxmerge.utils import read_docs
 @click.option("--filetype", prompt="SBoM output file type SPDX tag value format - T or JSON - J",
               help="Enter T for SPDX tag value format, J for JSON",
               type=click.Choice(['T', 't', 'J', 'j']), default='J')
-def main(docpath, name, version, mergetype, author, email, docnamespace, filetype, outpath=None):
+@click.option("--rootdocpath", prompt="SBoM root author", required=False, prompt_required=False,
+              default="",
+              help="SBoM that should be used as root author")
+def main(docpath, name, version, mergetype, author, email, docnamespace, filetype, rootdocpath, outpath=None):
     """Tool provides option to merge SPDX SBoM files. Provides two options for merging,
     Shallow Merge: New SBoM is created only with external ref links to SBoM files to be merged
     Deep Merge: New SBoM file is created by appending package, relationship, license information
     """
-    doc_list = read_docs(docpath)
+    doc_list, root_doc = read_docs(docpath, rootdocpath)
     merge_type = "shallow" if mergetype == '0' else "deep"
-    doc = create_merged_spdx_document(doc_list, docnamespace, name, version, author, email, merge_type)
+    doc = create_merged_spdx_document(doc_list, docnamespace, name, version, author, email, merge_type, root_doc)
     write_file(doc, filetype, merge_type, outpath)
 
 

--- a/spdxmerge/SPDXMergeLib.py
+++ b/spdxmerge/SPDXMergeLib.py
@@ -9,9 +9,9 @@ from spdx_tools.spdx.writer.tagvalue.tagvalue_writer import (
     write_document_to_file as write_tagvalue_document
 )
 
-def create_merged_spdx_document(doc_list, docnamespace, name, version, author, email, merge_type):
+def create_merged_spdx_document(doc_list, docnamespace, name, version, author, email, merge_type, root_doc):
     if merge_type == "deep":
-        merger = SPDX_DeepMerger(doc_list, docnamespace, name, version, author, email)
+        merger = SPDX_DeepMerger(doc_list, docnamespace, name, version, author, email, root_doc)
         merger.doc_packageinfo()
         merger.doc_fileinfo()
         merger.doc_snippetinfo()

--- a/spdxmerge/SPDX_DeepMerge.py
+++ b/spdxmerge/SPDX_DeepMerge.py
@@ -95,12 +95,14 @@ class SPDX_DeepMerger:
             
         else:
             found = False
+            # Find the SPDX element ID with the DESCRIBES relationship
             for rel in self.root_doc.relationships:
                 if rel.relationship_type == RelationshipType.DESCRIBES:
                     related_spdx_element_id = rel.related_spdx_element_id
                     found = True
                     break
             
+            # If no DESCRIBES relationship is found, raise an error
             if not found:
                 raise ValueError("Root document has no relationship of type DESCRIBES")
 

--- a/spdxmerge/utils.py
+++ b/spdxmerge/utils.py
@@ -2,12 +2,20 @@ import os
 from spdx_tools.spdx.parser import parse_anything
 from spdxmerge.checksum import sha1sum
 
-def read_docs(dir):
+def read_docs(dir, root_doc_path):
     doc_list = []
+    root_doc = None
     doc_files = [f for f in os.listdir(dir) if f.endswith(('.json', '.spdx'))]
+    if root_doc_path and root_doc_path in doc_files:
+        root_doc = parse_anything.parse_file(dir+"/"+root_doc_path)
+        root_doc.comment = sha1sum(dir+"/"+root_doc_path)
+    else:
+        if root_doc_path != '':
+            raise FileNotFoundError(f"Root document {root_doc_path} not found in directory {dir}.")
     for file in doc_files:
         doc = parse_anything.parse_file(dir+"/"+file)
         check_sum = sha1sum(dir+"/"+file)
         doc.comment = check_sum
         doc_list.append(doc)
-    return doc_list
+        
+    return doc_list, root_doc

--- a/spdxmerge/utils.py
+++ b/spdxmerge/utils.py
@@ -6,11 +6,14 @@ def read_docs(dir, root_doc_path):
     doc_list = []
     root_doc = None
     doc_files = [f for f in os.listdir(dir) if f.endswith(('.json', '.spdx'))]
+    
+    # Check if root document is present in the directory
     if root_doc_path and root_doc_path in doc_files:
         root_doc = parse_anything.parse_file(dir+"/"+root_doc_path)
         root_doc.comment = sha1sum(dir+"/"+root_doc_path)
     else:
         if root_doc_path != '':
+            # Raise error if --rootdocpath is defined but given root document is not found
             raise FileNotFoundError(f"Root document {root_doc_path} not found in directory {dir}.")
     for file in doc_files:
         doc = parse_anything.parse_file(dir+"/"+file)


### PR DESCRIPTION
This PR introduces a new optional parameter `rootdocpath` to use the given file as the root package. The given root file should also have a element with relation type `DESCRIBES`.

### Usage Examples
```py
python .\spdxmerge\SPDXMerge.py --docpath D:\temp\SBOM\input --outpath D:\temp\SBOM\output --name rootName --version rootVersion --mergetype 1 --author "rootAuthor" --docnamespace 
https://www.example.com --filetype J --rootdocpath "rootSPDX.spdx.json"
```