### PR TITLE
feat: add .dockerignore and improve Dockerfile to remove .git directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+.gitignore
+launch.json
+test/
+requirements-dev.txt
+CHANGELOG.md
+CONTRIBUTING.md
+CODEOWNERS
+LICENSE
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ FROM python:3.12.3
 WORKDIR /app
 COPY . /app
 
+# Remove .git directory if it was accidentally copied (defense in depth)
+RUN rm -rf /app/.git
+
 # Install pip requirements
 RUN pip install -r requirements.txt
 


### PR DESCRIPTION
`.git` should be excluded from ever being copied into a published docker image.